### PR TITLE
Light theme text on dark theme background

### DIFF
--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -12,10 +12,6 @@
     margin-top: 35px;
     border-radius: 5px;
 
-    .Post-body {
-      color: @text-color;
-    }
-
     .PostUser-badges, .PostUser-avatar {
       display: none;
     }


### PR DESCRIPTION
Fixes the issue of light theme text on dark theme background.

@text-color is defined by flarum, so when the flarum theme is light, @text-color is dark and when the flarum theme is dark, @text-color is light. The problem when using FoF/NightMode was when Night Mode was turned on, the flarum theme is still light and hence the @text-color is dark even though the theme is set to dark by the FoF/NightMode extension. With the minor commit da07312, I have set the font text inside the best-answer block to match with the forum theme text font. This way the best-answer block text will be visible in both day mode and night mode.