### PR TITLE
Add timestamp to best answer

### DIFF
--- a/js/src/forum/addBestAnswerAction.js
+++ b/js/src/forum/addBestAnswerAction.js
@@ -21,11 +21,13 @@ export default () => {
                 icon: `fa${isBestAnswer ? 's' : 'r'} fa-comment-dots`,
                 onclick: () => {
                     isBestAnswer = !isBestAnswer;
+                    let bestAnswerSetAt = Date.now();
 
                     discussion
                         .save({
                             bestAnswerPostId: isBestAnswer ? post.id() : 0,
                             bestAnswerUserId: app.session.user.id(),
+                            bestAnswerSetAt: bestAnswerSetAt,
                             relationships: isBestAnswer
                                 ? { bestAnswerPost: post, bestAnswerUser: app.session.user }
                                 : delete discussion.data.relationships.bestAnswerPost,
@@ -33,6 +35,7 @@ export default () => {
                         .then(() => {
                             if (app.current instanceof DiscussionPage) {
                                 app.current.stream.update();
+                                discussion.pushAttributes({ bestAnswerSetAt });
                             }
 
                             m.redraw();

--- a/js/src/forum/components/SelectBestAnswerItem.js
+++ b/js/src/forum/components/SelectBestAnswerItem.js
@@ -1,5 +1,6 @@
 import Component from 'flarum/Component';
 import icon from 'flarum/helpers/icon';
+import humanTime from 'flarum/helpers/humanTime';
 
 export default class SelectBestAnswerItem extends Component {
     view() {
@@ -22,10 +23,18 @@ export default class SelectBestAnswerItem extends Component {
                 <span className="BestAnswer--User">
                     {app.translator.trans('fof-best-answer.forum.best_answer_label', {
                         user: discussion.bestAnswerUser(),
+                        time_set: this.getSetTime(discussion),
                         a: <a onclick={() => m.route(app.route.user(discussion.bestAnswerUser()))} />,
                     })}
                 </span>
             </div>
         );
+    }
+
+    getSetTime(discussion) {
+        if (discussion.bestAnswerSetAt() === null) {
+            return;
+        }
+        return humanTime(discussion.bestAnswerSetAt());
     }
 }

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -13,6 +13,7 @@ app.initializers.add('fof/best-answer', () => {
     Discussion.prototype.startUserId = Model.attribute('startUserId', Number);
     Discussion.prototype.firstPostId = Model.attribute('firstPostId', Number);
     Discussion.prototype.canSelectBestAnswer = Model.attribute('canSelectBestAnswer');
+    Discussion.prototype.bestAnswerSetAt = Model.attribute('bestAnswerSetAt');
 
     app.notificationComponents.selectBestAnswer = SelectBestAnswerNotification;
 

--- a/migrations/2020_02_04_205300_add_best_answer_set_timestamp.php
+++ b/migrations/2020_02_04_205300_add_best_answer_set_timestamp.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of fof/best-answer.
+ *
+ * Copyright (c) 2019 FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        if (!$schema->hasColumn('discussions', 'best_answer_set_at')) {
+            $schema->table('discussions', function (Blueprint $table) {
+                $table->dateTime('best_answer_set_at')->nullable();
+                $table->index('best_answer_set_at');
+            });
+        }
+    },
+    'down' => function (Builder $schema) {
+        $schema->table('discussions', function (Blueprint $table) {
+            $table->dropColumn('best_answer_set_at');
+            $table->dropIndex('best_answer_set_at');
+        });
+    },
+];

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -12,7 +12,7 @@ fof-best-answer:
     this_best_answer: Select Best Answer
     remove_best_answer: Unselect Best Answer
     best_answer_button: Best Answer
-    best_answer_label: set by <a>{username}</a>
+    best_answer_label: set by <a>{username}</a> {time_set}
 
     notification:
       content: Please select a Best Answer if your question has been answered

--- a/src/Listeners/AddApiAttributes.php
+++ b/src/Listeners/AddApiAttributes.php
@@ -74,6 +74,9 @@ class AddApiAttributes
             $event->attributes['hasBestAnswer'] = $event->model->bestAnswerPost()->exists();
             $event->attributes['startUserId'] = $event->model->user_id;
             $event->attributes['firstPostId'] = $event->model->first_post_id;
+            if ($event->model->best_answer_set_at) {
+                $event->attributes['bestAnswerSetAt'] = $event->model->best_answer_set_at;
+            }
         }
 
         if ($event->isSerializer(ForumSerializer::class)) {

--- a/src/Listeners/SelectBestAnswer.php
+++ b/src/Listeners/SelectBestAnswer.php
@@ -11,6 +11,7 @@
 
 namespace FoF\BestAnswer\Listeners;
 
+use Carbon\Carbon;
 use Flarum\Discussion\Event\Saving;
 use Flarum\Notification\Notification;
 use Flarum\Notification\NotificationSyncer;
@@ -55,11 +56,13 @@ class SelectBestAnswer
         if ($id > 0) {
             $discussion->best_answer_post_id = $id;
             $discussion->best_answer_user_id = $event->actor->id;
+            $discussion->best_answer_set_at = Carbon::now();
 
             Notification::where('type', 'selectBestAnswer')->where('subject_id', $discussion->id)->delete();
         } elseif ($id == 0) {
             $discussion->best_answer_post_id = null;
             $discussion->best_answer_user_id = null;
+            $discussion->best_answer_set_at = null;
         }
 
         $this->notifications->delete(new SelectBestAnswerBlueprint($discussion));


### PR DESCRIPTION
At giffgaff we are currently using a fork of the old wiwatsrt version of best answers, with some of our own changes. This PR is the beginning of us making the switch over to fof/best-answer, and sharing our customizations and improvements.

@datitisev - I'm guessing to keep things simple, a seperate PR for each feature would be preferred, so here's the first :)

Here, we are logging the timestamp for when a best answer is set, and displaying it alongside the user who set it.

Customizable or removable via the locale file

Screenshot:
![image](https://user-images.githubusercontent.com/16573496/73795709-3012c800-47a3-11ea-83ab-98fb71d2ad11.png)
