### PR TITLE
Provide toggle between set/unset BA in PostControls or Post footer

### DIFF
--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -17,23 +17,23 @@ app.initializers.add('fof/best-answer', () => {
                     <BooleanItem key="fof-best-answer.allow_select_own_post">
                         {app.translator.trans('fof-best-answer.admin.settings.allow_select_own_post')}
                     </BooleanItem>,
-                    <BooleanItem key="fof-best-answer.use-alternative-ui">
-                        {app.translator.trans('fof-best-answer.admin.settings.use-alt-ui')}
+                    <BooleanItem key="fof-best-answer.use_alternative_ui">
+                        {app.translator.trans('fof-best-answer.admin.settings.use_alt_ui')}
                     </BooleanItem>,
                     <NumberItem key="fof-best-answer.select_best_answer_reminder_days" min="0" placeholder="0">
                         {app.translator.trans('fof-best-answer.admin.settings.select_best_answer_reminder_days')}
                     </NumberItem>,
-                    <StringItem key="fof-best-answer.remind-tag-ids">
-                        {app.translator.trans('fof-best-answer.admin.settings.remind-tag-ids')}
+                    <StringItem key="fof-best-answer.remind_tag_ids">
+                        {app.translator.trans('fof-best-answer.admin.settings.remind_tag_ids')}
                     </StringItem>,
-                    <BooleanItem key="fof-best-answer.schedule-on-one-server">
-                        {app.translator.trans('fof-best-answer.admin.settings.schedule-on-one-server')}
+                    <BooleanItem key="fof-best-answer.schedule_on_one_server">
+                        {app.translator.trans('fof-best-answer.admin.settings.schedule_on_one_server')}
                     </BooleanItem>,
-                    <BooleanItem key="fof-best-answer.stop-overnight">
-                        {app.translator.trans('fof-best-answer.admin.settings.schedule-stop-overnight')}
+                    <BooleanItem key="fof-best-answer.stop_overnight">
+                        {app.translator.trans('fof-best-answer.admin.settings.schedule_stop_overnight')}
                     </BooleanItem>,
-                    <BooleanItem key="fof-best-answer.store-log-output">
-                        {app.translator.trans('fof-best-answer.admin.settings.schedule-log-output')}
+                    <BooleanItem key="fof-best-answer.store_log_output">
+                        {app.translator.trans('fof-best-answer.admin.settings.schedule_log_output')}
                     </BooleanItem>,
                 ],
             })

--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -17,6 +17,9 @@ app.initializers.add('fof/best-answer', () => {
                     <BooleanItem key="fof-best-answer.allow_select_own_post">
                         {app.translator.trans('fof-best-answer.admin.settings.allow_select_own_post')}
                     </BooleanItem>,
+                    <BooleanItem key="fof-best-answer.use-alternative-ui">
+                        {app.translator.trans('fof-best-answer.admin.settings.use-alt-ui')}
+                    </BooleanItem>,
                     <NumberItem key="fof-best-answer.select_best_answer_reminder_days" min="0" placeholder="0">
                         {app.translator.trans('fof-best-answer.admin.settings.select_best_answer_reminder_days')}
                     </NumberItem>,

--- a/js/src/forum/addBestAnswerAction.js
+++ b/js/src/forum/addBestAnswerAction.js
@@ -5,6 +5,44 @@ import DiscussionPage from 'flarum/components/DiscussionPage';
 import CommentPost from 'flarum/components/CommentPost';
 
 export default () => {
+    const ineligible = (discussion, post) => {
+        return post.isHidden() || post.number() === 1 || !discussion.canSelectBestAnswer() || !app.session.user
+    };
+
+    const blockSelectOwnPost = (post) => {
+        return !app.forum.attribute('canSelectBestAnswerOwnPost') && post.user() && post.user().id() === app.session.user.id();
+    };
+
+    const isThisBestAnswer = (discussion, post) => {
+        return discussion.bestAnswerPost() && discussion.bestAnswerPost().id() === post.id();
+    };
+
+    const actionLabel = (isBestAnswer) => {
+        return app.translator.trans(isBestAnswer ? 'fof-best-answer.forum.remove_best_answer' : 'fof-best-answer.forum.this_best_answer');
+    };
+
+    const saveDiscussion = (discussion, isBestAnswer, post) => {
+        discussion
+            .save({
+                bestAnswerPostId: isBestAnswer ? post.id() : 0,
+                bestAnswerUserId: app.session.user.id(),
+                relationships: isBestAnswer
+                    ? { bestAnswerPost: post, bestAnswerUser: app.session.user }
+                    : delete discussion.data.relationships.bestAnswerPost,
+            })
+            .then(() => {
+                if (app.current instanceof DiscussionPage) {
+                    app.current.stream.update();
+                }
+
+                m.redraw();
+
+                if (isBestAnswer) {
+                    m.route(app.route.discussion(discussion));
+                }
+            });
+    };
+
     extend(PostControls, 'moderationControls', function (items, post) {
         if (app.forum.attribute('useAlternativeBestAnswerUi')) return;
 
@@ -57,42 +95,4 @@ export default () => {
             })
         );
     });
-
-    const ineligible = (discussion, post) => {
-        return post.isHidden() || post.number() === 1 || !discussion.canSelectBestAnswer() || !app.session.user
-    };
-
-    const blockSelectOwnPost = (post) => {
-        return !app.forum.attribute('canSelectBestAnswerOwnPost') && post.user() && post.user().id() === app.session.user.id();
-    };
-
-    const isThisBestAnswer = (discussion, post) => {
-        return discussion.bestAnswerPost() && discussion.bestAnswerPost().id() === post.id();
-    };
-
-    const actionLabel = (isBestAnswer) => {
-        return app.translator.trans(isBestAnswer ? 'fof-best-answer.forum.remove_best_answer' : 'fof-best-answer.forum.this_best_answer');
-    };
-
-    const saveDiscussion = (discussion, isBestAnswer, post) => {
-        discussion
-            .save({
-                bestAnswerPostId: isBestAnswer ? post.id() : 0,
-                bestAnswerUserId: app.session.user.id(),
-                relationships: isBestAnswer
-                    ? { bestAnswerPost: post, bestAnswerUser: app.session.user }
-                    : delete discussion.data.relationships.bestAnswerPost,
-            })
-            .then(() => {
-                if (app.current instanceof DiscussionPage) {
-                    app.current.stream.update();
-                }
-
-                m.redraw();
-
-                if (isBestAnswer) {
-                    m.route(app.route.discussion(discussion));
-                }
-            });
-    };
 };

--- a/js/src/forum/addBestAnswerAction.js
+++ b/js/src/forum/addBestAnswerAction.js
@@ -2,9 +2,12 @@ import { extend } from 'flarum/extend';
 import Button from 'flarum/components/Button';
 import PostControls from 'flarum/utils/PostControls';
 import DiscussionPage from 'flarum/components/DiscussionPage';
+import CommentPost from 'flarum/components/CommentPost';
 
 export default () => {
-    extend(PostControls, 'moderationControls', function(items, post) {
+    extend(PostControls, 'moderationControls', function (items, post) {
+        if (app.forum.attribute('useAlternativeBestAnswerUi')) return;
+
         const discussion = post.discussion();
         let isBestAnswer = discussion.bestAnswerPost() && discussion.bestAnswerPost().id() === post.id();
 
@@ -45,4 +48,63 @@ export default () => {
             })
         );
     });
+
+    extend(CommentPost.prototype, 'actionItems', function (items) {
+        if (!app.forum.attribute('useAlternativeBestAnswerUi')) return;
+
+        const post = this.props.post;
+        const discussion = this.props.post.discussion();
+        let isBestAnswer = discussion.bestAnswerPost() && discussion.bestAnswerPost().id() === post.id();
+        let hasBestAnswer = discussion.bestAnswerPost() !== false;
+
+        post.pushAttributes({ isBestAnswer });
+
+        if (post.isHidden() || post.number() === 1 || !discussion.canSelectBestAnswer() || !app.session.user) return;
+
+        if (discussion.startUserId() === Number.parseInt(app.session.user.id()) && discussion.canSelectBestAnswer()) {
+            commonItem(items, post, discussion, isBestAnswer);
+        }
+
+        if (!discussion.canSelectBestAnswer()
+            || discussion.startUserId() === Number.parseInt(app.session.user.id())) return;
+
+        commonItem(items, post, discussion, isBestAnswer, hasBestAnswer);
+
+    });
+
+    const commonItem = (items, post, discussion, isBestAnswer, hasBestAnswer) => {
+        items.add(
+            'bestAnswer',
+            Button.component({
+                children: app.translator.trans(
+                    isBestAnswer ? 'fof-best-answer.forum.remove_best_answer' : 'fof-best-answer.forum.this_best_answer'
+                ),
+                className: !hasBestAnswer ? 'Button Button--primary' : (isBestAnswer ? 'Button Button--primary' : 'Button Button--link'),
+                onclick: function onclick() {
+                    hasBestAnswer = !hasBestAnswer;
+                    isBestAnswer = !isBestAnswer;
+
+                    discussion
+                        .save({
+                            bestAnswerPostId: isBestAnswer ? post.id() : 0,
+                            bestAnswerUserId: app.session.user.id(),
+                            relationships: isBestAnswer
+                                ? { bestAnswerPost: post, bestAnswerUser: app.session.user }
+                                : delete discussion.data.relationships.bestAnswerPost,
+                        })
+                        .then(() => {
+                            if (app.current instanceof DiscussionPage) {
+                                app.current.stream.update();
+                            }
+
+                            m.redraw();
+
+                        });
+                    if (isBestAnswer) {
+                        m.route(app.route.discussion(discussion));
+                    }
+                },
+            })
+        );
+    };
 };

--- a/js/src/forum/addBestAnswerAction.js
+++ b/js/src/forum/addBestAnswerAction.js
@@ -13,12 +13,14 @@ export default () => {
 
         post.pushAttributes({ isBestAnswer });
 
+        if (post.contentType() !== 'comment') return;
+
         if (ineligible(discussion, post) || blockSelectOwnPost(post)) return;
 
         items.add(
             'bestAnswer',
             Button.component({
-                children: app.translator.trans(isBestAnswer ? 'fof-best-answer.forum.remove_best_answer' : 'fof-best-answer.forum.this_best_answer'),
+                children: actionLabel(isBestAnswer),
                 icon: `fa${isBestAnswer ? 's' : 'r'} fa-comment-dots`,
                 onclick: () => {
                     isBestAnswer = !isBestAnswer;
@@ -44,9 +46,7 @@ export default () => {
         items.add(
             'bestAnswer',
             Button.component({
-                children: app.translator.trans(
-                    isBestAnswer ? 'fof-best-answer.forum.remove_best_answer' : 'fof-best-answer.forum.this_best_answer'
-                ),
+                children: actionLabel(isBestAnswer),
                 className: !hasBestAnswer ? 'Button Button--primary' : (isBestAnswer ? 'Button Button--primary' : 'Button Button--link'),
                 onclick: function onclick() {
                     hasBestAnswer = !hasBestAnswer;
@@ -56,7 +56,6 @@ export default () => {
                 },
             })
         );
-
     });
 
     const ineligible = (discussion, post) => {
@@ -69,6 +68,10 @@ export default () => {
 
     const isThisBestAnswer = (discussion, post) => {
         return discussion.bestAnswerPost() && discussion.bestAnswerPost().id() === post.id();
+    };
+
+    const actionLabel = (isBestAnswer) => {
+        return app.translator.trans(isBestAnswer ? 'fof-best-answer.forum.remove_best_answer' : 'fof-best-answer.forum.this_best_answer');
     };
 
     const saveDiscussion = (discussion, isBestAnswer, post) => {

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -1,4 +1,5 @@
 import { extend } from 'flarum/extend';
+import app from 'flarum/app';
 import Discussion from 'flarum/models/Discussion';
 import Model from 'flarum/Model';
 import NotificationGrid from 'flarum/components/NotificationGrid';

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -30,7 +30,7 @@ app.initializers.add('fof/best-answer', () => {
         items.add('awardedBestAnswer', {
             name: 'awardedBestAnswer',
             icon: 'fas fa-check',
-            label: app.translator.trans('fof-best-answer.forum.notification.preferences.awarded-best-answer'),
+            label: app.translator.trans('fof-best-answer.forum.notification.preferences.awarded_best_answer'),
         });
     });
 });

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -67,3 +67,11 @@
     }
   }
 }
+
+.Post-actions {
+  .item-bestAnswer {
+    .Button--primary {
+      margin: 0px 10px;
+    }
+  }
+}

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -11,6 +11,7 @@ fof-best-answer:
       schedule-stop-overnight: Prevent the reminder scheduler from running during unsocial hours (9pm - 8am server time)
       schedule-log-output: Append scheduler output to log storage
       remind-tag-ids: To restrict reminders to particular tags, enter the tag ID's here (comma seperated)
+      use-alt-ui: Use alternative layout (best answer buttons in post footer)
   forum:
     answered_badge: Answered
     this_best_answer: Select Best Answer

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -7,11 +7,11 @@ fof-best-answer:
       title: FriendsOfFlarum Best Answer
       allow_select_own_post: Allow users to select their own posts
       select_best_answer_reminder_days: Remind users to select a best answer after X days
-      schedule-on-one-server: Use 'onOneServer()' directive for the task scheduler (requires Redis/Memcache)
-      schedule-stop-overnight: Prevent the reminder scheduler from running during unsocial hours (9pm - 8am server time)
-      schedule-log-output: Append scheduler output to log storage
-      remind-tag-ids: To restrict reminders to particular tags, enter the tag ID's here (comma seperated)
-      use-alt-ui: Use alternative layout (best answer buttons in post footer)
+      schedule_on_one_server: Use 'onOneServer()' directive for the task scheduler (requires Redis/Memcache)
+      schedule_stop_overnight: Prevent the reminder scheduler from running during unsocial hours (9pm - 8am server time)
+      schedule_log_output: Append scheduler output to log storage
+      remind_tag_ids: To restrict reminders to particular tags, enter the tag ID's here (comma seperated)
+      use_alt_ui: Use alternative layout (best answer buttons in post footer)
   forum:
     answered_badge: Answered
     this_best_answer: Select Best Answer
@@ -22,7 +22,7 @@ fof-best-answer:
     notification:
       content: Please select a Best Answer if your question has been answered
       awarded: Your post was set as the best answer by {username}
-      awarded-email: Your post was set as the best answer by user
-      select-email-title: Did you manage to sort your problem?
+      awarded_email: Your post was set as the best answer by user
+      select_email_title: Did you manage to sort your problem?
       preferences:
-        awarded-best-answer: When someone sets my post as a best answer
+        awarde_best_answer: When someone sets my post as a best answer

--- a/src/Console/NotifyCommand.php
+++ b/src/Console/NotifyCommand.php
@@ -79,7 +79,7 @@ class NotifyCommand extends Command
         $query = Discussion::query();
 
         if ($this->extensions->isEnabled('flarum-tags')) {
-            $tags = explode(',', $this->settings->get('fof-best-answer.remind-tag-ids'));
+            $tags = explode(',', $this->settings->get('fof-best-answer.remind_tag_ids'));
             if ($tags) {
                 $query->leftJoin('discussion_tag', 'discussion_tag.discussion_id', '=', 'discussions.id');
                 $query->whereIn('discussion_tag.tag_id', $tags);

--- a/src/DefaultSettings.php
+++ b/src/DefaultSettings.php
@@ -31,14 +31,14 @@ class DefaultSettings implements LifecycleInterface
     public function onEnable(Container $container, Extension $extension)
     {
         if ($extension->name === 'fof/best-answer') {
-            if (($this->settings->get('fof-best-answer.schedule-on-one-server')) === null) {
-                $this->settings->set('fof-best-answer.schedule-on-one-server', false);
+            if (($this->settings->get('fof-best-answer.schedule_on_one_server')) === null) {
+                $this->settings->set('fof-best-answer.schedul_on_one_server', false);
             }
-            if (($this->settings->get('fof-best-answer.stop-overnight')) === null) {
-                $this->settings->set('fof-best-answer.stop-overnight', false);
+            if (($this->settings->get('fof-best-answer.stop_overnight')) === null) {
+                $this->settings->set('fof-best-answer.stop_overnight', false);
             }
-            if (($this->settings->get('fof-best-answer.store-log-output')) === null) {
-                $this->settings->set('fof-best-answer.store-log-output', true);
+            if (($this->settings->get('fof-best-answer.store_log_output')) === null) {
+                $this->settings->set('fof-best-answer.store_log_output', true);
             }
         }
     }

--- a/src/Listeners/AddApiAttributes.php
+++ b/src/Listeners/AddApiAttributes.php
@@ -83,7 +83,7 @@ class AddApiAttributes
 
         if ($event->isSerializer(ForumSerializer::class)) {
             $event->attributes['canSelectBestAnswerOwnPost'] = (bool) app('flarum.settings')->get('fof-best-answer.allow_select_own_post');
-            $event->attributes['useAlternativeBestAnswerUi'] = (bool) app('flarum.settings')->get('fof-best-answer.use-alternative-ui', false);
+            $event->attributes['useAlternativeBestAnswerUi'] = (bool) app('flarum.settings')->get('fof-best-answer.use_alternative_ui', false);
         }
     }
 

--- a/src/Listeners/AddApiAttributes.php
+++ b/src/Listeners/AddApiAttributes.php
@@ -83,6 +83,7 @@ class AddApiAttributes
 
         if ($event->isSerializer(ForumSerializer::class)) {
             $event->attributes['canSelectBestAnswerOwnPost'] = (bool) app('flarum.settings')->get('fof-best-answer.allow_select_own_post');
+            $event->attributes['useAlternativeBestAnswerUi'] = (bool) app('flarum.settings')->get('fof-best-answer.use-alternative-ui', false);
         }
     }
 

--- a/src/Notification/AwardedBestAnswerBlueprint.php
+++ b/src/Notification/AwardedBestAnswerBlueprint.php
@@ -101,7 +101,7 @@ class AwardedBestAnswerBlueprint implements BlueprintInterface, MailableInterfac
      */
     public function getEmailSubject()
     {
-        return $this->translator->trans('fof-best-answer.forum.notification.awarded-email', [
+        return $this->translator->trans('fof-best-answer.forum.notification.awarded_email', [
             'user'  => $this->actor->username,
             'title' => $this->discussion->title,
         ]);

--- a/src/Notification/SelectBestAnswerBlueprint.php
+++ b/src/Notification/SelectBestAnswerBlueprint.php
@@ -87,7 +87,7 @@ class SelectBestAnswerBlueprint implements BlueprintInterface, MailableInterface
      */
     public function getEmailSubject()
     {
-        return $this->translator->trans('fof-best-answer.forum.notification.select-email-title', [
+        return $this->translator->trans('fof-best-answer.forum.notification.select_email_title', [
             'title' => $this->discussion->title,
         ]);
     }

--- a/src/Provider/ConsoleProvider.php
+++ b/src/Provider/ConsoleProvider.php
@@ -36,16 +36,16 @@ class ConsoleProvider extends AbstractServiceProvider
                 ->hourly()
                 ->withoutOverlapping();
 
-            if ((bool) $settings->get('fof-best-answer.schedule-on-one-server')) {
+            if ((bool) $settings->get('fof-best-answer.schedule_on_one_server')) {
                 $build->onOneServer();
             }
 
-            if ((bool) $settings->get('fof-best-answer.stop-overnight')) {
+            if ((bool) $settings->get('fof-best-answer.stop_overnight')) {
                 $build->between('8:00', '21:00');
                 //TODO expose times back to config options
             }
 
-            if ((bool) $settings->get('fof-best-answer.store-log-output')) {
+            if ((bool) $settings->get('fof-best-answer.store_log_output')) {
                 $build->appendOutputTo(storage_path('logs'.DIRECTORY_SEPARATOR.'fof-best-answer.log'));
             }
         });


### PR DESCRIPTION
Providing a toggle option to switch between having set/unset actions in either `PostControls` or post footer.

<img width="612" alt="Screenshot 2020-02-07 at 19 06 17" src="https://user-images.githubusercontent.com/16573496/74057978-f200e880-49dc-11ea-969b-fa0c307d6d3a.png">

<img width="878" alt="Screenshot 2020-02-07 at 19 07 38" src="https://user-images.githubusercontent.com/16573496/74058063-207ec380-49dd-11ea-9df2-22d737d3fd66.png">

vs

<img width="874" alt="Screenshot 2020-02-07 at 19 08 27" src="https://user-images.githubusercontent.com/16573496/74058116-4015ec00-49dd-11ea-96d0-55a781dfba7f.png">
