### PR TITLE
Address cross discussion vulnerability

### DIFF
--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -18,6 +18,8 @@ fof-best-answer:
     remove_best_answer: Unselect Best Answer
     best_answer_button: Best Answer
     best_answer_label: set by <a>{username}</a> {time_set}
+    errors:
+      mismatch: "Selected post does not exist in this discussion"
 
     notification:
       best_answer_in_discussion: "{username} set a best answer in this discussion"

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -33,4 +33,9 @@ class Helpers
             ? $canSelectOwnPost && $can
             : $can;
     }
+
+    public static function postBelongsToTargetDiscussion(Post $post, Discussion $discussion): bool
+    {
+        return $post->discussion_id === $discussion->id;
+    }
 }

--- a/src/Listeners/SelectBestAnswer.php
+++ b/src/Listeners/SelectBestAnswer.php
@@ -64,7 +64,7 @@ class SelectBestAnswer
             );
         }
 
-        if ($post && !Helpers::canSelectPostAsBestAnswer($event->actor, $post) || $post && !$post->isVisibleTo($event->actor)) {
+        if ($post && (!Helpers::canSelectPostAsBestAnswer($event->actor, $post) || !$post->isVisibleTo($event->actor))) {
             throw new PermissionDeniedException();
         }
 

--- a/src/Listeners/SelectBestAnswer.php
+++ b/src/Listeners/SelectBestAnswer.php
@@ -56,8 +56,7 @@ class SelectBestAnswer
         $post = $event->discussion->posts()->find($id);
 
         // If 'id' = 0, then we are removing a best answer.
-        //
-        if ($id > 0 && Helpers::postBelongsToTargetDiscussion($post, $discussion)) {
+       if ($id > 0 && Helpers::postBelongsToTargetDiscussion($post, $discussion)) {
             throw new ValidationException(
                 [
                     'error' => app('translator')->trans('fof-best-answer.forum.errors.mismatch'),

--- a/src/Listeners/SelectBestAnswer.php
+++ b/src/Listeners/SelectBestAnswer.php
@@ -56,11 +56,11 @@ class SelectBestAnswer
         $post = $event->discussion->posts()->find($id);
 
         // If 'id' = 0, then we are removing a best answer.
-        // 
+        //
         if ($id > 0 && Helpers::postBelongsToTargetDiscussion($post, $discussion)) {
             throw new ValidationException(
                 [
-                    'error' => app('translator')->trans('fof-best-answer.forum.errors.mismatch')
+                    'error' => app('translator')->trans('fof-best-answer.forum.errors.mismatch'),
                 ]
             );
         }

--- a/src/Listeners/SelectBestAnswer.php
+++ b/src/Listeners/SelectBestAnswer.php
@@ -64,7 +64,7 @@ class SelectBestAnswer
             );
         }
 
-        if ($post && !Helpers::canSelectPostAsBestAnswer($event->actor, $post)) {
+        if ($post && !Helpers::canSelectPostAsBestAnswer($event->actor, $post) || $post && !$post->isVisibleTo($event->actor)) {
             throw new PermissionDeniedException();
         }
 

--- a/src/Listeners/SelectBestAnswer.php
+++ b/src/Listeners/SelectBestAnswer.php
@@ -56,7 +56,7 @@ class SelectBestAnswer
         $post = $event->discussion->posts()->find($id);
 
         // If 'id' = 0, then we are removing a best answer.
-       if ($id > 0 && Helpers::postBelongsToTargetDiscussion($post, $discussion)) {
+        if ($id > 0 && Helpers::postBelongsToTargetDiscussion($post, $discussion)) {
             throw new ValidationException(
                 [
                     'error' => app('translator')->trans('fof-best-answer.forum.errors.mismatch'),

--- a/src/Listeners/SelectBestAnswer.php
+++ b/src/Listeners/SelectBestAnswer.php
@@ -54,7 +54,7 @@ class SelectBestAnswer
 
         $post = $event->discussion->posts()->find($id);
 
-        if ($post && !Helpers::canSelectPostAsBestAnswer($event->actor, $post)) {
+        if ($post && !Helpers::canSelectPostAsBestAnswer($event->actor, $post) || $id > 0 && !Helpers::postBelongsToTargetDiscussion($post, $discussion)) {
             throw new PermissionDeniedException();
         }
 

--- a/src/Listeners/SelectBestAnswer.php
+++ b/src/Listeners/SelectBestAnswer.php
@@ -56,7 +56,7 @@ class SelectBestAnswer
         $post = $event->discussion->posts()->find($id);
 
         // If 'id' = 0, then we are removing a best answer.
-        if ($id > 0 && Helpers::postBelongsToTargetDiscussion($post, $discussion)) {
+        if ($id > 0 && !Helpers::postBelongsToTargetDiscussion($post, $discussion)) {
             throw new ValidationException(
                 [
                     'error' => app('translator')->trans('fof-best-answer.forum.errors.mismatch'),


### PR DESCRIPTION
We discovered it was possible to tamper with the `POST` request triggered by setting a best answer, and provide an alternative `post_id`, belonging to another discussion. This alternative post contents would then be rendered in the best answer panel. 

This PR adds an additional check that the supplied `post_id` belongs to the correct discussion.