### PR TITLE
Stop BA button showing on PostsUserPage

### DIFF
--- a/js/src/forum/addBestAnswerAction.js
+++ b/js/src/forum/addBestAnswerAction.js
@@ -31,7 +31,7 @@ export default () => {
                     : delete discussion.data.relationships.bestAnswerPost,
             })
             .then(() => {
-                if (app.current instanceof DiscussionPage) {
+                if (app.current.matches(DiscussionPage)) {
                     app.current.stream.update();
                 }
 
@@ -54,6 +54,8 @@ export default () => {
         if (post.contentType() !== 'comment') return;
 
         if (ineligible(discussion, post) || blockSelectOwnPost(post)) return;
+
+        if (!app.current.matches(DiscussionPage)) return;
 
         items.add(
             'bestAnswer',
@@ -82,6 +84,8 @@ export default () => {
         post.pushAttributes({ isBestAnswer });
 
         if (ineligible(discussion, post) || blockSelectOwnPost(post)) return;
+
+        if (!app.current.matches(DiscussionPage)) return;
 
         items.add(
             'bestAnswer',


### PR DESCRIPTION
Flarum does annoying and mean caching of data (which is actually good, but let's pretend it's not for the sake of this PR) between pages.

While the BA button does not appear if you go to a user's posts page directly, if you visit after viewing a discussion where one of their posts is on their user page, and you have BA permissions, the BA button shows.

This PR ensures the button only displays if the current view is `DiscussionPage`, and will show no BA button on other routes.