### PR TITLE
Update forum.less

### DIFF
--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -15,9 +15,9 @@
 .Post-footer {
   width: 100%;
   .item-bestAnswerPost {
-    padding: 10px;
+    padding: 10px 10px 0 10px;
     background-color: @best-answer-post-background;
-    margin-top: 35px;
+    margin-top: 20px;
     border-radius: 5px;
 
     .Post-body {


### PR DESCRIPTION
**Changes proposed in this pull request:**
Currently the light grey horizontal border/line after the first post overlaps into the green best answer box. I've removed padding on the bottom to prevent this. I also decreased the amount of space above the green box. I feel like the original 35px is a bit much.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [NA] Backend changes: tests are green (run `composer test`).