### PR TITLE
Fix incompatibility with fof/ban-ips and possibly other

### DIFF
--- a/src/UserBestAnswerCount.php
+++ b/src/UserBestAnswerCount.php
@@ -44,7 +44,9 @@ class UserBestAnswerCount
         // Use a standalone query and not attribute update+save because otherwise data added by extensions
         // with Extend\ApiController::prepareDataForSerialization() ends up being added to the SQL UPDATE clause,
         // and breaks Flarum since those are often not real columns
-        $user->newQuery()->update(['best_answer_count' => $count]);
+        $user->newQuery()
+            ->where('id', $user->id)
+            ->update(['best_answer_count' => $count]);
 
         return $count;
     }

--- a/src/UserBestAnswerCount.php
+++ b/src/UserBestAnswerCount.php
@@ -41,8 +41,10 @@ class UserBestAnswerCount
             ->where('posts.user_id', $user->id)
             ->count();
 
-        $user->best_answer_count = $count;
-        $user->save();
+        // Use a standalone query and not attribute update+save because otherwise data added by extensions
+        // with Extend\ApiController::prepareDataForSerialization() ends up being added to the SQL UPDATE clause,
+        // and breaks Flarum since those are often not real columns
+        $user->newQuery()->update(['best_answer_count' => $count]);
 
         return $count;
     }


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Fixes error
```
Next Illuminate\Database\QueryException: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'banned_ips' in 'field list' (SQL: update `bbsbear_users` set `best_answer_count` = 0, `banned_ips` = [] where `id` = 2) in /www/wwwroot/mydomain.com/vendor/illuminate/database/Connection.php:712
```

which has been reported a few times on the forums. It happens when both best-answer and ban-ips are enabled and that you register a new user or access the profile of a user who hasn't had their best answer count updated yet.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
