### PR TITLE
Fix visually incompatibility with `imorland/level-ranks`

### DIFF
--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -9,6 +9,7 @@
   & > ul > li.item-isBestAnswer {
     display: inline-block;
     margin-top: 3px;
+    margin-right: 60px;
   }
 }
 


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Add a right margin to prevent the `.Post-header>ul` collapse into one line too early that will cause the `.item-isBestAnswer` stack on the user rank indicator from the extension [imorland/level-ranks](https://github.com/imorland/level-ranks) when the viewport width is within >422px and <769px.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
I don't know will this change introduce new conflict with other extensions.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
Can be reproduce at https://n0099.net/v/d/3239/6
![image](https://user-images.githubusercontent.com/13030387/180644539-7ede0f84-045d-4cc2-8a46-5844f974b1ab.png)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [x] The user rank indicator under mobile viewport is introduced in [this pr](https://github.com/imorland/level-ranks/issues/2).
