### PR TITLE
fix: migrations assume flarum is already installed

### DIFF
--- a/migrations/2019_11_04_000003_migrate_extension_settings.php
+++ b/migrations/2019_11_04_000003_migrate_extension_settings.php
@@ -17,19 +17,17 @@ $permissionKey = 'discussion.selectBestAnswerOwnDiscussion';
 
 return [
     'up' => function (Builder $schema) use ($permissionKey) {
-        /**
-         * @var \Flarum\Settings\SettingsRepositoryInterface
-         */
-        $settings = resolve('flarum.settings');
+        $db = $schema->getConnection();
 
         foreach (['allow_select_own_post', 'select_best_answer_reminder_days'] as $setting) {
-            if ($value = $settings->get($key = "flarum-best-answer.$setting")) {
-                $settings->set("fof-best-answer.$setting", $value);
-                $settings->delete($key);
+            $query = $db->table('settings')
+                ->where('key', "flarum-best-answer.$setting");
+
+            if ($query->exists()) {
+                $query->update(['key' => "fof-best-answer.$setting"]);
             }
         }
 
-        $db = $schema->getConnection();
         $permission = $db->table('group_permission')
             ->where('permission', 'discussion.selectBestAnswer');
 

--- a/migrations/2019_11_04_000003_migrate_extension_settings.php
+++ b/migrations/2019_11_04_000003_migrate_extension_settings.php
@@ -20,12 +20,9 @@ return [
         $db = $schema->getConnection();
 
         foreach (['allow_select_own_post', 'select_best_answer_reminder_days'] as $setting) {
-            $query = $db->table('settings')
-                ->where('key', "flarum-best-answer.$setting");
-
-            if ($query->exists()) {
-                $query->update(['key' => "fof-best-answer.$setting"]);
-            }
+            $db->table('settings')
+                ->where('key', "flarum-best-answer.$setting")
+                ->update(['key' => "fof-best-answer.$setting"]);
         }
 
         $permission = $db->table('group_permission')

--- a/migrations/2021_09_10_add_default_filter_option_setting.php
+++ b/migrations/2021_09_10_add_default_filter_option_setting.php
@@ -17,7 +17,7 @@ return [
 
         $db->table('settings')
             ->insert([
-                'key' => 'fof-best-answer.show_filter_dropdown',
+                'key'   => 'fof-best-answer.show_filter_dropdown',
                 'value' => true,
             ]);
     },

--- a/migrations/2021_09_10_add_default_filter_option_setting.php
+++ b/migrations/2021_09_10_add_default_filter_option_setting.php
@@ -13,16 +13,17 @@ use Illuminate\Database\Schema\Builder;
 
 return [
     'up' => function (Builder $schema) {
-        /**
-         * @var \Flarum\Settings\SettingsRepositoryInterface
-         */
-        $settings = resolve('flarum.settings');
+        $db = $schema->getConnection();
 
-        $settings->set('fof-best-answer.show_filter_dropdown', true);
+        $db->table('settings')
+            ->insert([
+                'key' => 'fof-best-answer.show_filter_dropdown',
+                'value' => true,
+            ]);
     },
     'down' => function (Builder $schema) {
         /**
-         * @var \Flarum\Settings\SettingsRepositoryInterface
+         * @var \Flarum\Settings\SettingsRepositoryInterface $settings
          */
         $settings = resolve('flarum.settings');
 


### PR DESCRIPTION
Relates to https://github.com/flarum/framework/pull/3655

**Changes proposed in this pull request:**
Use Schema DB connection instead of resolving `flarum.settings`. 
More info @ https://github.com/FriendsOfFlarum/reactions/pull/55.

**Reviewers should focus on:**
I don't think the `down` migration needs this change as the forum would be installed at that point.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tests are green (run `composer test`).
