### PR TITLE
fix: resolving the container in migrations prevents running them on-app-install

### DIFF
--- a/migrations/2021_09_10_add_default_filter_option_setting.php
+++ b/migrations/2021_09_10_add_default_filter_option_setting.php
@@ -13,20 +13,17 @@ use Illuminate\Database\Schema\Builder;
 
 return [
     'up' => function (Builder $schema) {
-        $db = $schema->getConnection();
-
-        $db->table('settings')
+        $schema->getConnection()
+            ->table('settings')
             ->insert([
                 'key'   => 'fof-best-answer.show_filter_dropdown',
                 'value' => true,
             ]);
     },
     'down' => function (Builder $schema) {
-        /**
-         * @var \Flarum\Settings\SettingsRepositoryInterface $settings
-         */
-        $settings = resolve('flarum.settings');
-
-        $settings->delete('fof-best-answer.show_filter_dropdown');
+        $schema->getConnection()
+            ->table('settings')
+            ->where('key', 'fof-best-answer.show_filter_dropdown')
+            ->delete();
     },
 ];


### PR DESCRIPTION
Resolving the container within migrations prevents running the migrations when first installing flarum. It's better to directly use the connection, which is also faster 🎉 