### PR TITLE
feat: allow secondary tags to be q&a enabled

### DIFF
--- a/js/src/admin/components/BestAnswerSettingsPage.tsx
+++ b/js/src/admin/components/BestAnswerSettingsPage.tsx
@@ -17,11 +17,6 @@ export default class BestAnswerSettingsPage extends ExtensionPage {
                 help: app.translator.trans('fof-best-answer.admin.settings.enabled_tags_help'),
                 options: {
                   requireParentTag: false,
-                  limits: {
-                    max: {
-                      secondary: 0,
-                    },
-                  },
                 },
               })}
               {this.buildSettingComponent({
@@ -31,11 +26,6 @@ export default class BestAnswerSettingsPage extends ExtensionPage {
                 help: app.translator.trans('fof-best-answer.admin.settings.remind_tags_help'),
                 options: {
                   requireParentTag: false,
-                  limits: {
-                    max: {
-                      secondary: 0,
-                    },
-                  },
                 },
               })}
             </div>


### PR DESCRIPTION
Implements #92 

The code actually already supports this, just the tag selector was restricting to primary tags only