### PR TITLE
chore: change condition for filter gambit

### DIFF
--- a/src/Search/BestAnswerFilterGambit.php
+++ b/src/Search/BestAnswerFilterGambit.php
@@ -49,10 +49,9 @@ class BestAnswerFilterGambit extends AbstractRegexGambit implements FilterInterf
         $actor = $search->getActor();
 
         $search->getQuery()->where(function ($query) use ($negate, $actor) {
-            $method = $negate ? 'whereNotIn' : 'whereIn';
             $methodBestAnswerPostId = $negate ? 'whereNull' : 'whereNotNull';
 
-            $query->$method('discussions.id', function ($query) use ($actor) {
+            $query->whereIn('discussions.id', function ($query) use ($actor) {
                 $query->select('discussion_id')
                     ->from('discussion_tag')
                     ->whereIn('tag_id', $this->allowedQnATags($actor))


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

Report by @novacuum

> I stumbled upon this change: https://github.com/FriendsOfFlarum/best-answer/commit/b97010304707e1be311d65385a88f17ffc16acad
> My indention was to select discussions without a solved post, but this is not possible, as in the negation it excludes the discussions which have the tags with qna enabled.
> From my understanding, the method call in line 54 (old code) was correct, only the field was wrong.
> It should only change the check for discussions.best_answer_post_id , is null or notnull

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
