### PR TITLE
fix condition for filter gambit (search only)

### DIFF
--- a/src/Search/BestAnswerFilterGambit.php
+++ b/src/Search/BestAnswerFilterGambit.php
@@ -49,10 +49,9 @@ class BestAnswerFilterGambit extends AbstractRegexGambit implements FilterInterf
         $actor = $search->getActor();
 
         $search->getQuery()->where(function ($query) use ($negate, $actor) {
-            $method = $negate ? 'whereNotIn' : 'whereIn';
             $methodBestAnswerPostId = $negate ? 'whereNull' : 'whereNotNull';
 
-            $query->$method('discussions.id', function ($query) use ($actor) {
+            $query->whereIn('discussions.id', function ($query) use ($actor) {
                 $query->select('discussion_id')
                     ->from('discussion_tag')
                     ->whereIn('tag_id', $this->allowedQnATags($actor))

--- a/tests/integration/search/BestAnswerFilterGambitTest.php
+++ b/tests/integration/search/BestAnswerFilterGambitTest.php
@@ -24,13 +24,13 @@ class BestAnswerFilterGambitTest extends TestCase
             ],
             'discussions' => [
                 ['id' => 1, 'title' => __CLASS__, 'user_id' => 1, 'created_at' => Carbon::now(), 'comment_count' => 2, 'best_answer_post_id' => null],
-                ['id' => 2, 'title' => __CLASS__, 'user_id' => 1, 'created_at' => Carbon::now(), 'comment_count' => 2, 'best_answer_post_id' => 4, 'best_answer_user_id' => 1, 'best_answer_set_at' => Carbon::now()],
+                ['id' => 2, 'title' => __CLASS__, 'user_id' => 1, 'created_at' => Carbon::now(), 'comment_count' => 2, 'best_answer_post_id' => 4, 'best_answer_user_id' => 3, 'best_answer_set_at' => Carbon::now()],
             ],
             'posts' => [
                 ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => 'post 1', 'created_at' => Carbon::now()],
                 ['id' => 2, 'discussion_id' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => 'post 2', 'created_at' => Carbon::now()],
                 ['id' => 3, 'discussion_id' => 2, 'user_id' => 2, 'type' => 'comment', 'content' => 'post 1', 'created_at' => Carbon::now()],
-                ['id' => 4, 'discussion_id' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => 'post 2', 'created_at' => Carbon::now()],
+                ['id' => 4, 'discussion_id' => 2, 'user_id' => 3, 'type' => 'comment', 'content' => 'post 2', 'created_at' => Carbon::now()],
             ],
             'tags' => [
                 ['id' => 1, 'name' => 'Tag 1', 'slug' => 'tag-1', 'description' => 'Tag 1 description', 'color' => '#FF0000', 'position' => 0, 'parent_id' => null, 'is_restricted' => false, 'is_hidden' => false, 'is_qna' => true],
@@ -42,19 +42,16 @@ class BestAnswerFilterGambitTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
     public function test_positive_filtering()
     {
         $response = $this->send(
             $this->request(
                 'GET',
-                '/api/discussions?filter[solved-discussions]=1',
+                '/api/discussions',
                 [
-                    'authenticatedAs' => 1,
+                    'authenticatedAs' => 2,
                 ]
-            )
+            )->withQueryParams(['filter' => ['solved-discussions' => 1]])
         );
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -65,19 +62,56 @@ class BestAnswerFilterGambitTest extends TestCase
         $this->assertEquals(2, $data['data'][0]['id']);
     }
 
-    /**
-     * @test
-     */
     public function test_negative_filtering()
     {
         $response = $this->send(
             $this->request(
                 'GET',
-                '/api/discussions?filter[!solved-discussions]=1',
+                '/api/discussions',
                 [
-                    'authenticatedAs' => 1,
+                    'authenticatedAs' => 2,
                 ]
-            )
+            )->withQueryParams(['filter' => ['-solved-discussions' => 1]])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertCount(1, $data['data']);
+        $this->assertEquals(1, $data['data'][0]['id']);
+    }
+
+    public function test_positive_search()
+    {
+        $response = $this->send(
+            $this->request(
+                'GET',
+                '/api/discussions',
+                [
+                    'authenticatedAs' => 2,
+                ]
+            )->withQueryParams(['filter' => ['q' => 'is:solved']])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertCount(1, $data['data']);
+        $this->assertEquals(2, $data['data'][0]['id']);
+    }
+
+    public function test_negative_search()
+    {
+        $response = $this->send(
+            $this->request(
+                'GET',
+                '/api/discussions',
+                [
+                    'authenticatedAs' => 2,
+                ]
+            )->withQueryParams(['filter' => ['q' => '-is:solved']])
         );
 
         $this->assertEquals(200, $response->getStatusCode());

--- a/tests/integration/search/BestAnswerFilterGambitTest.php
+++ b/tests/integration/search/BestAnswerFilterGambitTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace FoF\BestAnswer\tests\integration\search;
+
+use Carbon\Carbon;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+
+class BestAnswerFilterGambitTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('flarum-tags');
+        $this->extension('fof-best-answer');
+
+        $this->prepareDatabase([
+            'users' => [
+                $this->normalUser(),
+                ['id' => 3, 'username' => 'normal2', 'email' => 'normal2@machine.local', 'best_answer_count' => 1],
+            ],
+            'discussions' => [
+                ['id' => 1, 'title' => __CLASS__, 'user_id' => 1, 'created_at' => Carbon::now(), 'comment_count' => 2, 'best_answer_post_id' => null],
+                ['id' => 2, 'title' => __CLASS__, 'user_id' => 1, 'created_at' => Carbon::now(), 'comment_count' => 2, 'best_answer_post_id' => 4, 'best_answer_user_id' => 1, 'best_answer_set_at' => Carbon::now()],
+            ],
+            'posts' => [
+                ['id' => 1, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => 'post 1', 'created_at' => Carbon::now()],
+                ['id' => 2, 'discussion_id' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => 'post 2', 'created_at' => Carbon::now()],
+                ['id' => 3, 'discussion_id' => 2, 'user_id' => 2, 'type' => 'comment', 'content' => 'post 1', 'created_at' => Carbon::now()],
+                ['id' => 4, 'discussion_id' => 2, 'user_id' => 1, 'type' => 'comment', 'content' => 'post 2', 'created_at' => Carbon::now()],
+            ],
+            'tags' => [
+                ['id' => 1, 'name' => 'Tag 1', 'slug' => 'tag-1', 'description' => 'Tag 1 description', 'color' => '#FF0000', 'position' => 0, 'parent_id' => null, 'is_restricted' => false, 'is_hidden' => false, 'is_qna' => true],
+            ],
+            'discussion_tag' => [
+                ['discussion_id' => 1, 'tag_id' => 1],
+                ['discussion_id' => 2, 'tag_id' => 1],
+            ],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function test_positive_filtering()
+    {
+        $response = $this->send(
+            $this->request(
+                'GET',
+                '/api/discussions?filter[solved-discussions]=1',
+                [
+                    'authenticatedAs' => 1,
+                ]
+            )
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertCount(1, $data['data']);
+        $this->assertEquals(2, $data['data'][0]['id']);
+    }
+
+    /**
+     * @test
+     */
+    public function test_negative_filtering()
+    {
+        $response = $this->send(
+            $this->request(
+                'GET',
+                '/api/discussions?filter[!solved-discussions]=1',
+                [
+                    'authenticatedAs' => 1,
+                ]
+            )
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertCount(1, $data['data']);
+        $this->assertEquals(1, $data['data'][0]['id']);
+    }
+}

--- a/tests/integration/search/BestAnswerFilterGambitTest.php
+++ b/tests/integration/search/BestAnswerFilterGambitTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/best-answer.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\BestAnswer\tests\integration\search;
 
 use Carbon\Carbon;


### PR DESCRIPTION
Fixes #0000

Report by @novacuum

    I stumbled upon this change: https://github.com/FriendsOfFlarum/best-answer/commit/b97010304707e1be311d65385a88f17ffc16acad
    My indention was to select discussions without a solved post, but this is not possible, as in the negation it excludes the discussions which have the tags with qna enabled.
    From my understanding, the method call in line 54 (old code) was correct, only the field was wrong.
    It should only change the check for discussions.best_answer_post_id , is null or notnull

Changes proposed in this pull request:

Reviewers should focus on:

Screenshot

Confirmed

Frontend changes: tested on a local Flarum installation.

    Backend changes: tests are green (run composer test).

Required changes:

Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)