### PR TITLE
fix: pass tag object as prop to filter

### DIFF
--- a/js/src/forum/components/SolvedFilter.tsx
+++ b/js/src/forum/components/SolvedFilter.tsx
@@ -5,7 +5,7 @@ import Button from 'flarum/common/components/Button';
 import type Tag from 'flarum/tags/common/models/Tag';
 
 export interface SolvedFilterAttrs extends ComponentAttrs {
-  currentTag: Tag;
+  currentTag?: Tag;
   alwaysShow?: boolean;
 }
 

--- a/js/src/forum/components/SolvedFilter.tsx
+++ b/js/src/forum/components/SolvedFilter.tsx
@@ -5,6 +5,7 @@ import Button from 'flarum/common/components/Button';
 import type Tag from 'flarum/tags/common/models/Tag';
 
 export interface SolvedFilterAttrs extends ComponentAttrs {
+  currentTag: Tag;
   alwaysShow?: boolean;
 }
 
@@ -50,15 +51,13 @@ export default class SolvedFilter extends Component<SolvedFilterAttrs> {
   }
 
   shouldShowFilter() {
-    const { alwaysShow } = this.attrs;
+    const { currentTag, alwaysShow } = this.attrs;
 
     if (alwaysShow) return true;
 
     if (!app.forum.attribute('showBestAnswerFilterUi')) return false;
 
-    const tag: Tag = app.current.get('tag');
-
-    if (!tag?.isQnA?.()) {
+    if (!currentTag?.isQnA?.()) {
       if (app.discussions.bestAnswer) {
         delete app.discussions.bestAnswer;
         app.discussions.refresh();

--- a/js/src/forum/extenders/extendIndexPage.tsx
+++ b/js/src/forum/extenders/extendIndexPage.tsx
@@ -2,6 +2,7 @@ import app from 'flarum/forum/app';
 import { extend } from 'flarum/common/extend';
 import IndexPage from 'flarum/forum/components/IndexPage';
 import SolvedFilter from '../components/SolvedFilter';
+import type Tag from 'flarum/tags/common/models/Tag';
 
 export default function extendIndexPage() {
   extend(IndexPage.prototype, 'sidebarItems', function (items) {
@@ -21,6 +22,10 @@ export default function extendIndexPage() {
   });
 
   extend(IndexPage.prototype, 'viewItems', function (items) {
-    items.add('solved-filter', <SolvedFilter />);
+    const currentTag: Tag | undefined = this.currentTag();
+
+    if (!currentTag) return;
+
+    items.add('solved-filter', <SolvedFilter currentTag={currentTag} />);
   });
 }


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**
Filter Dropdown was not showing at all

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
