### PR TITLE
chore: don't manipulate newDiscussion item if inexistent

### DIFF
--- a/js/src/forum/extenders/extendIndexPage.tsx
+++ b/js/src/forum/extenders/extendIndexPage.tsx
@@ -11,6 +11,9 @@ export default function extendIndexPage() {
     if (!tag?.isQnA?.()) return;
 
     const canStartDiscussion = app.forum.attribute('canStartDiscussion') || !app.session.user;
+
+    if (!items.has('newDiscussion')) return;
+
     const cta = items.get('newDiscussion');
     cta.children = app.translator.trans(
       canStartDiscussion ? 'fof-best-answer.forum.index.ask_question' : 'fof-best-answer.forum.index.cannot_ask_question'


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
Allows for compatibility with themes where the `newDiscussion` button doesn't exist (was removed) but the remainder of the fof/best-answer features still are used

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
