### PR TITLE
[2.x] feat: select own post permission

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -77,6 +77,7 @@ return [
         }),
 
     (new Extend\ApiResource(Resource\PostResource::class))
+        ->fields(Api\PostAttributes::class)
         ->endpoint(Endpoint\Index::class, function (Endpoint\Index $endpoint) {
             return $endpoint
                 ->addDefaultInclude(['discussion.bestAnswerPost', 'discussion.bestAnswerUser', 'discussion.bestAnswerPost.user']); // @todo: same

--- a/js/src/@types/shims.d.ts
+++ b/js/src/@types/shims.d.ts
@@ -14,7 +14,6 @@ declare module 'flarum/common/models/Discussion' {
     hasBestAnswer(): boolean | undefined;
     bestAnswerPost(): Post | null;
     bestAnswerUser(): User | null;
-    canSelectBestAnswer(): boolean;
     bestAnswerSetAt(): Date | null;
   }
 }
@@ -35,5 +34,11 @@ declare module 'flarum/forum/states/DiscussionListState' {
 declare module 'flarum/common/models/User' {
   export default interface User {
     bestAnswerCount(): number;
+  }
+}
+
+declare module 'flarum/common/models/Post' {
+  export default interface Post {
+    canSelectAsBestAnswer(): boolean;
   }
 }

--- a/js/src/admin/components/BestAnswerSettingsPage.tsx
+++ b/js/src/admin/components/BestAnswerSettingsPage.tsx
@@ -33,12 +33,6 @@ export default class BestAnswerSettingsPage extends ExtensionPage {
             <div className="Section">
               {this.buildSettingComponent({
                 type: 'boolean',
-                setting: 'fof-best-answer.allow_select_own_post',
-                label: app.translator.trans('fof-best-answer.admin.settings.allow_select_own_post'),
-                help: app.translator.trans('fof-best-answer.admin.settings.allow_select_own_post_help'),
-              })}
-              {this.buildSettingComponent({
-                type: 'boolean',
                 setting: 'fof-best-answer.use_alternative_ui',
                 label: app.translator.trans('fof-best-answer.admin.settings.use_alt_ui'),
                 help: app.translator.trans('fof-best-answer.admin.settings.use_alt_ui_help'),

--- a/js/src/admin/extend.ts
+++ b/js/src/admin/extend.ts
@@ -1,3 +1,4 @@
+import app from 'flarum/admin/app';
 import Extend from 'flarum/common/extenders';
 import BestAnswerSettingsPage from './components/BestAnswerSettingsPage';
 import commonExtend from '../common/extend';
@@ -20,6 +21,14 @@ export default [
         icon: 'far fa-comment',
         label: app.translator.trans('fof-best-answer.admin.permissions.best_answer_not_own_discussion'),
         permission: 'discussion.selectBestAnswerNotOwnDiscussion',
+      }),
+      'reply'
+    )
+    .permission(
+      () => ({
+        icon : 'fas fa-check',
+        label: app.translator.trans('fof-best-answer.admin.permissions.allow_select_own_post'),
+        permission: 'discussion.fof-best-answer.allow_select_own_post'
       }),
       'reply'
     ),

--- a/js/src/admin/extend.ts
+++ b/js/src/admin/extend.ts
@@ -26,9 +26,9 @@ export default [
     )
     .permission(
       () => ({
-        icon : 'fas fa-check',
+        icon: 'fas fa-check',
         label: app.translator.trans('fof-best-answer.admin.permissions.allow_select_own_post'),
-        permission: 'discussion.fof-best-answer.allow_select_own_post'
+        permission: 'discussion.fof-best-answer.allow_select_own_post',
       }),
       'reply'
     ),

--- a/js/src/forum/addBestAnswerAction.tsx
+++ b/js/src/forum/addBestAnswerAction.tsx
@@ -10,7 +10,7 @@ import extractText from 'flarum/common/utils/extractText';
 
 export default function addBestAnswerAction() {
   const ineligible = (discussion: Discussion, post: Post) => {
-    return post.isHidden() || post.number() === 1 || !discussion.canSelectBestAnswer() || !app.session.user;
+    return post.isHidden() || post.number() === 1 || !post.canSelectAsBestAnswer() || !app.session.user;
   };
 
   const isThisBestAnswer = (discussion: Discussion, post: Post): boolean => {

--- a/js/src/forum/addBestAnswerAction.tsx
+++ b/js/src/forum/addBestAnswerAction.tsx
@@ -13,11 +13,6 @@ export default function addBestAnswerAction() {
     return post.isHidden() || post.number() === 1 || !discussion.canSelectBestAnswer() || !app.session.user;
   };
 
-  const blockSelectOwnPost = (post: Post): boolean => {
-    const user = post.user();
-    return !app.forum.attribute<boolean>('canSelectBestAnswerOwnPost') && user !== false && user.id() === app.session.user?.id();
-  };
-
   const isThisBestAnswer = (discussion: Discussion, post: Post): boolean => {
     const bAPost = discussion.bestAnswerPost();
     const hasBestAnswer = discussion.hasBestAnswer();
@@ -72,7 +67,7 @@ export default function addBestAnswerAction() {
 
     if (post.contentType() !== 'comment') return;
 
-    if (ineligible(discussion, post) || blockSelectOwnPost(post) || !app.current.matches(DiscussionPage)) return;
+    if (ineligible(discussion, post) || !app.current.matches(DiscussionPage)) return;
 
     items.add(
       'bestAnswer',
@@ -101,7 +96,7 @@ export default function addBestAnswerAction() {
 
     post.pushAttributes({ isBestAnswer });
 
-    if (ineligible(discussion, post) || blockSelectOwnPost(post) || !app.current.matches(DiscussionPage)) return;
+    if (ineligible(discussion, post) || !app.current.matches(DiscussionPage)) return;
 
     items.add(
       'bestAnswer',

--- a/js/src/forum/addBestAnswerAction.tsx
+++ b/js/src/forum/addBestAnswerAction.tsx
@@ -14,9 +14,9 @@ export default function addBestAnswerAction() {
   };
 
   const isThisBestAnswer = (discussion: Discussion, post: Post): boolean => {
-    const bAPost = discussion.bestAnswerPost();
+    const bAPost = discussion.bestAnswerPost?.();
     const hasBestAnswer = discussion.hasBestAnswer();
-    return hasBestAnswer !== undefined && hasBestAnswer && bAPost !== null && bAPost.id() === post.id();
+    return hasBestAnswer !== undefined && hasBestAnswer && bAPost !== null && bAPost.id?.() === post.id();
   };
 
   const actionLabel = (isBestAnswer: boolean): string => {

--- a/js/src/forum/extend.ts
+++ b/js/src/forum/extend.ts
@@ -1,7 +1,7 @@
 import Discussion from 'flarum/common/models/Discussion';
 import commonExtend from '../common/extend';
 import Extend from 'flarum/common/extenders';
-import type Post from 'flarum/common/models/Post';
+import Post from 'flarum/common/models/Post';
 import User from 'flarum/common/models/User';
 import Model from 'flarum/common/Model';
 
@@ -12,9 +12,11 @@ export default [
     .hasOne<Post>('bestAnswerPost')
     .hasOne<User>('bestAnswerUser')
     .attribute<boolean | number>('hasBestAnswer')
-    .attribute<boolean>('canSelectBestAnswer')
     .attribute('bestAnswerSetAt', Model.transformDate),
 
   new Extend.Model(User) //
     .attribute<number>('bestAnswerCount'),
+
+  new Extend.Model(Post) //
+    .attribute<boolean>('canSelectAsBestAnswer'),
 ];

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -3,6 +3,7 @@ fof-best-answer:
     permissions:
       best_answer: Select Best Answer (own Discussion)
       best_answer_not_own_discussion: Select Best Answer (not own Discussion)
+      allow_select_own_post: Select own post as Best Answer
     settings:
       label:
         tags: Best Answer Tags
@@ -10,8 +11,6 @@ fof-best-answer:
         reminders: Reminders
         advanced: Advanced
         reminders_notice: For reminders to function, you must have set up the Flarum scheduler correctly.
-      allow_select_own_post: Select own post
-      allow_select_own_post_help: Allow a user to select their own post as a best answer to a discussion
       show_max_lines_label: Max lines to show in post preview
       show_max_lines_help: Set to 0 to disable. If a post is longer than the configured amount of lines, it will be truncated in the post preview with a fade out effect.
       select_best_answer_reminder_days: Reminder frequency

--- a/src/Api/ForumAttributes.php
+++ b/src/Api/ForumAttributes.php
@@ -11,6 +11,7 @@
 
 namespace FoF\BestAnswer\Api;
 
+use Flarum\Api\Context;
 use Flarum\Api\Schema;
 use Flarum\Settings\SettingsRepositoryInterface;
 
@@ -24,9 +25,6 @@ class ForumAttributes
     public function __invoke(): array
     {
         return [
-            Schema\Boolean::make('canSelectBestAnswerOwnPost')
-                ->get(fn () => (bool) $this->settings->get('fof-best-answer.allow_select_own_post')),
-
             Schema\Boolean::make('bestAnswerDiscussionSidebarJumpButton')
                 ->get(fn () => (bool) $this->settings->get('fof-best-answer.discussion_sidebar_jump_button')),
 

--- a/src/Api/ForumAttributes.php
+++ b/src/Api/ForumAttributes.php
@@ -11,7 +11,6 @@
 
 namespace FoF\BestAnswer\Api;
 
-use Flarum\Api\Context;
 use Flarum\Api\Schema;
 use Flarum\Settings\SettingsRepositoryInterface;
 

--- a/src/Api/PostAttributes.php
+++ b/src/Api/PostAttributes.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace FoF\BestAnswer\Api;
+
+use Flarum\Api\Context;
+use Flarum\Api\Schema;
+use Flarum\Post\Post;
+use FoF\BestAnswer\Repository\BestAnswerRepository;
+
+class PostAttributes
+{
+    public function __construct(
+        protected BestAnswerRepository $bestAnswerRepository,
+    ) {
+    }
+
+    public function __invoke(): array
+    {
+        return [
+            Schema\Boolean::make('canSelectAsBestAnswer')
+                ->get(fn (Post $post, Context $context) => $this->bestAnswerRepository->canSelectPostAsBestAnswer($context->getActor(), $post)),
+        ];
+    }
+}

--- a/src/Api/PostAttributes.php
+++ b/src/Api/PostAttributes.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/best-answer.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\BestAnswer\Api;
 
 use Flarum\Api\Context;

--- a/src/Console/NotifyCommand.php
+++ b/src/Console/NotifyCommand.php
@@ -40,7 +40,6 @@ class NotifyCommand extends Command
     public function handle()
     {
         $days = (int) $this->settings->get('fof-best-answer.select_best_answer_reminder_days');
-        $canSelectOwn = (bool) (int) $this->settings->get('fof-best-answer.allow_select_own_post');
         $time = Carbon::now()->subDays($days);
 
         // set a max time period to go back, so we don't spam really old discussions too.
@@ -76,11 +75,12 @@ class NotifyCommand extends Command
 
         $errors = [];
 
-        $query->chunkById(20, function ($discussions) use ($canSelectOwn, &$errors) {
+        $query->chunkById(20, function ($discussions) use (&$errors) {
             // Filter out discussions where the user can't select a post as best answer.
             // - The user must have permission to select a best answer on their own discussion
             // - The user must be able to select a post, whether they can select any post (including their own) or not.
-            $discussions = $discussions->filter(function ($d) use ($canSelectOwn) {
+            $discussions = $discussions->filter(function ($d) {
+                $canSelectOwn = $d->user->can('fof-best-answer.allow_select_own_post', $d);
                 $hasPermission = $d->user->can('selectBestAnswerOwnDiscussion', $d);
                 $canSelectPosts = $canSelectOwn || $d->posts()->where('user_id', '!=', $d->user_id)->count() != 0;
 

--- a/src/Repository/BestAnswerRepository.php
+++ b/src/Repository/BestAnswerRepository.php
@@ -50,7 +50,7 @@ class BestAnswerRepository
         }
 
         if ($user->id === $post->user_id) {
-            return (bool) $this->settings->get('fof-best-answer.allow_select_own_post');
+            return $user->can('discussion.fof-best-answer.allow_select_own_post', $post->discussion);
         }
 
         return true;

--- a/src/Repository/BestAnswerRepository.php
+++ b/src/Repository/BestAnswerRepository.php
@@ -50,7 +50,7 @@ class BestAnswerRepository
         }
 
         if ($user->id === $post->user_id) {
-            return $user->can('discussion.fof-best-answer.allow_select_own_post', $post->discussion);
+            return $user->can('fof-best-answer.allow_select_own_post', $post->discussion);
         }
 
         return true;

--- a/tests/integration/api/SetBestAnswerTest.php
+++ b/tests/integration/api/SetBestAnswerTest.php
@@ -59,7 +59,7 @@ class SetBestAnswerTest extends TestCase
             ],
             'group_permission' => [
                 ['group_id' => 4, 'permission' => 'discussion.selectBestAnswerNotOwnDiscussion', 'created_at' => Carbon::now()],
-                ['group_id' => 4, 'permission' => 'discussion.fof-best-answer.allow_select_own_post', 'created_at' => Carbon::now()]
+                ['group_id' => 4, 'permission' => 'discussion.fof-best-answer.allow_select_own_post', 'created_at' => Carbon::now()],
             ],
             'group_user' => [
                 ['user_id' => 4, 'group_id' => 4],

--- a/tests/integration/api/SetBestAnswerTest.php
+++ b/tests/integration/api/SetBestAnswerTest.php
@@ -59,6 +59,7 @@ class SetBestAnswerTest extends TestCase
             ],
             'group_permission' => [
                 ['group_id' => 4, 'permission' => 'discussion.selectBestAnswerNotOwnDiscussion', 'created_at' => Carbon::now()],
+                ['group_id' => 4, 'permission' => 'discussion.fof-best-answer.allow_select_own_post', 'created_at' => Carbon::now()]
             ],
             'group_user' => [
                 ['user_id' => 4, 'group_id' => 4],
@@ -166,20 +167,36 @@ class SetBestAnswerTest extends TestCase
         $this->assertEquals(403, $response->getStatusCode());
     }
 
-    #[Test]
-    public function user_cannot_set_own_post_as_best_answer_if_not_permitted()
+    public static function unauthorizedUsersOwnPostProvider(): array
     {
-        $response = $this->setBestAnswer(3, 5, 2);
+        return [
+            [2],
+            [3],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('unauthorizedUsersOwnPostProvider')]
+    public function user_cannot_set_own_post_as_best_answer_if_not_permitted(int $userId)
+    {
+        $response = $this->setBestAnswer($userId, 5, 2);
 
         $this->assertEquals(403, $response->getStatusCode());
     }
 
-    #[Test]
-    public function user_can_set_own_post_as_best_answer_if_permitted()
+    public static function permittedUsersOwnPostProvider(): array
     {
-        $this->setting('fof-best-answer.allow_select_own_post', true);
+        return [
+            [1],
+            [4],
+        ];
+    }
 
-        $response = $this->setBestAnswer(3, 5, 2);
+    #[Test]
+    #[DataProvider('permittedUsersOwnPostProvider')]
+    public function user_can_set_own_post_as_best_answer_if_permitted(int $userId)
+    {
+        $response = $this->setBestAnswer($userId, 5, 2);
 
         $this->assertEquals(200, $response->getStatusCode());
 


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**

Removes the previous `Select own post as best answer` setting and replaces it with tag scoped permissions, to allow for finer control over which users can perform this action

**Reviewers should focus on:**
Note the translation key change from `fof-best-answer.admin.settings.allow_select_own_post` to `fof-best-answer.admin.permissions.allow_select_own_post`

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
