### PR TITLE
feat!: implement select own post permission

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -68,8 +68,8 @@ return [
         ->type(Notification\AwardedBestAnswerBlueprint::class, Serializer\BasicDiscussionSerializer::class, ['alert'])
         ->type(Notification\BestAnswerSetInDiscussionBlueprint::class, Serializer\BasicDiscussionSerializer::class, []),
 
-    (new Extend\ApiSerializer(Serializer\DiscussionSerializer::class))
-        ->attributes(Api\DiscussionAttributes::class),
+    (new Extend\ApiSerializer(Serializer\PostSerializer::class))
+        ->attributes(Api\PostAttributes::class),
 
     (new Extend\ApiSerializer(Serializer\BasicDiscussionSerializer::class))
         ->hasOne('bestAnswerPost', Serializer\BasicPostSerializer::class)

--- a/js/src/@types/shims.d.ts
+++ b/js/src/@types/shims.d.ts
@@ -14,7 +14,6 @@ declare module 'flarum/common/models/Discussion' {
     hasBestAnswer(): boolean | undefined;
     bestAnswerPost(): Post | null;
     bestAnswerUser(): User | null;
-    canSelectBestAnswer(): boolean;
     bestAnswerSetAt(): Date | null;
   }
 }
@@ -35,5 +34,11 @@ declare module 'flarum/forum/states/DiscussionListState' {
 declare module 'flarum/common/models/User' {
   export default interface User {
     bestAnswerCount(): number;
+  }
+}
+
+declare module 'flarum/common/models/Post' {
+  export default interface Post {
+    canSelectAsBestAnswer(): boolean;
   }
 }

--- a/js/src/admin/components/BestAnswerSettingsPage.tsx
+++ b/js/src/admin/components/BestAnswerSettingsPage.tsx
@@ -33,12 +33,6 @@ export default class BestAnswerSettingsPage extends ExtensionPage {
             <div className="Section">
               {this.buildSettingComponent({
                 type: 'boolean',
-                setting: 'fof-best-answer.allow_select_own_post',
-                label: app.translator.trans('fof-best-answer.admin.settings.allow_select_own_post'),
-                help: app.translator.trans('fof-best-answer.admin.settings.allow_select_own_post_help'),
-              })}
-              {this.buildSettingComponent({
-                type: 'boolean',
                 setting: 'fof-best-answer.use_alternative_ui',
                 label: app.translator.trans('fof-best-answer.admin.settings.use_alt_ui'),
                 help: app.translator.trans('fof-best-answer.admin.settings.use_alt_ui_help'),

--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -25,6 +25,14 @@ app.initializers.add(
           permission: 'discussion.selectBestAnswerNotOwnDiscussion',
         },
         'reply'
+      )
+      .registerPermission(
+        {
+          icon: 'fas fa-check',
+          label: app.translator.trans('fof-best-answer.admin.permissions.allow_select_own_post'),
+          permission: 'discussion.fof-best-answer.allow_select_own_post',
+        },
+        'reply'
       );
 
     addBestAnswerCountSort();

--- a/js/src/forum/addBestAnswerAction.tsx
+++ b/js/src/forum/addBestAnswerAction.tsx
@@ -10,18 +10,13 @@ import extractText from 'flarum/common/utils/extractText';
 
 export default function addBestAnswerAction() {
   const ineligible = (discussion: Discussion, post: Post) => {
-    return post.isHidden() || post.number() === 1 || !discussion.canSelectBestAnswer() || !app.session.user;
-  };
-
-  const blockSelectOwnPost = (post: Post): boolean => {
-    const user = post.user();
-    return !app.forum.attribute<boolean>('canSelectBestAnswerOwnPost') && user !== false && user.id() === app.session.user?.id();
+    return post.isHidden() || post.number() === 1 || !post.canSelectAsBestAnswer() || !app.session.user;
   };
 
   const isThisBestAnswer = (discussion: Discussion, post: Post): boolean => {
-    const bestAnswerPost = discussion.bestAnswerPost();
+    const bestAnswerPost = discussion.bestAnswerPost?.();
     const hasBestAnswer = discussion.hasBestAnswer();
-    return hasBestAnswer !== undefined && hasBestAnswer && bestAnswerPost !== null && bestAnswerPost.id() === post.id();
+    return hasBestAnswer !== undefined && hasBestAnswer && !!bestAnswerPost && bestAnswerPost.id?.() === post.id();
   };
 
   const actionLabel = (isBestAnswer: boolean): string => {
@@ -71,7 +66,7 @@ export default function addBestAnswerAction() {
 
     if (post.contentType() !== 'comment') return;
 
-    if (ineligible(discussion, post) || blockSelectOwnPost(post) || !app.current.matches(DiscussionPage)) return;
+    if (ineligible(discussion, post) || !app.current.matches(DiscussionPage)) return;
 
     items.add(
       'bestAnswer',
@@ -100,7 +95,7 @@ export default function addBestAnswerAction() {
 
     post.pushAttributes({ isBestAnswer });
 
-    if (ineligible(discussion, post) || blockSelectOwnPost(post) || !app.current.matches(DiscussionPage)) return;
+    if (ineligible(discussion, post) || !app.current.matches(DiscussionPage)) return;
 
     items.add(
       'bestAnswer',

--- a/js/src/forum/extend.ts
+++ b/js/src/forum/extend.ts
@@ -1,7 +1,7 @@
 import Discussion from 'flarum/common/models/Discussion';
 import commonExtend from '../common/extend';
 import Extend from 'flarum/common/extenders';
-import type Post from 'flarum/common/models/Post';
+import Post from 'flarum/common/models/Post';
 import User from 'flarum/common/models/User';
 import Model from 'flarum/common/Model';
 
@@ -12,9 +12,11 @@ export default [
     .hasOne<Post>('bestAnswerPost')
     .hasOne<User>('bestAnswerUser')
     .attribute<boolean | number>('hasBestAnswer')
-    .attribute<boolean>('canSelectBestAnswer')
     .attribute('bestAnswerSetAt', Model.transformDate),
 
   new Extend.Model(User) //
     .attribute<number>('bestAnswerCount'),
+
+  new Extend.Model(Post) //
+    .attribute<boolean>('canSelectAsBestAnswer'),
 ];

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -3,6 +3,7 @@ fof-best-answer:
     permissions:
       best_answer: Select Best Answer (own Discussion)
       best_answer_not_own_discussion: Select Best Answer (not own Discussion)
+      allow_select_own_post: Select own post as Best Answer
     settings:
       label:
         tags: Best Answer Tags
@@ -11,8 +12,6 @@ fof-best-answer:
         search: Search
         advanced: Advanced
         reminders_notice: For reminders to function, you must have set up the Flarum scheduler correctly.
-      allow_select_own_post: Select own post
-      allow_select_own_post_help: Allow a user to select their own post as a best answer to a discussion
       show_max_lines_label: Max lines to show in post preview
       show_max_lines_help: Set to 0 to disable. If a post is longer than the configured amount of lines, it will be truncated in the post preview with a fade out effect.
       select_best_answer_reminder_days: Reminder frequency

--- a/src/Api/ForumAttributes.php
+++ b/src/Api/ForumAttributes.php
@@ -34,7 +34,6 @@ class ForumAttributes
         }
 
         $attributes['solutionSearchEnabled'] = $value;
-        $attributes['canSelectBestAnswerOwnPost'] = $this->getBooleanSetting('fof-best-answer.allow_select_own_post');
         $attributes['useAlternativeBestAnswerUi'] = $this->getBooleanSetting('fof-best-answer.use_alternative_ui');
         $attributes['showBestAnswerFilterUi'] = $this->getBooleanSetting('fof-best-answer.show_filter_dropdown');
         $attributes['bestAnswerDiscussionSidebarJumpButton'] = $this->getBooleanSetting('fof-best-answer.discussion_sidebar_jump_button');

--- a/src/Api/PostAttributes.php
+++ b/src/Api/PostAttributes.php
@@ -17,7 +17,7 @@ use FoF\BestAnswer\Repository\BestAnswerRepository;
 
 class PostAttributes
 {
-   /**
+    /**
      * @var BestAnswerRepository
      */
     protected $bestAnswerRepository;

--- a/src/Api/PostAttributes.php
+++ b/src/Api/PostAttributes.php
@@ -29,8 +29,6 @@ class PostAttributes
 
     public function __invoke(PostSerializer $serializer, Post $post, array $attributes): array
     {
-        resolve('log')->info($this->bestAnswerRepository->canSelectPostAsBestAnswer($serializer->getActor(), $post));
-
         $attributes['canSelectAsBestAnswer'] = $this->bestAnswerRepository->canSelectPostAsBestAnswer($serializer->getActor(), $post);
 
         return $attributes;

--- a/src/Api/PostAttributes.php
+++ b/src/Api/PostAttributes.php
@@ -11,13 +11,13 @@
 
 namespace FoF\BestAnswer\Api;
 
-use Flarum\Api\Serializer\DiscussionSerializer;
-use Flarum\Discussion\Discussion;
+use Flarum\Api\Serializer\PostSerializer;
+use Flarum\Post\Post;
 use FoF\BestAnswer\Repository\BestAnswerRepository;
 
-class DiscussionAttributes
+class PostAttributes
 {
-    /**
+   /**
      * @var BestAnswerRepository
      */
     protected $bestAnswerRepository;
@@ -27,9 +27,11 @@ class DiscussionAttributes
         $this->bestAnswerRepository = $bestAnswerRepository;
     }
 
-    public function __invoke(DiscussionSerializer $serializer, Discussion $discussion, array $attributes): array
+    public function __invoke(PostSerializer $serializer, Post $post, array $attributes): array
     {
-        $attributes['canSelectBestAnswer'] = $this->bestAnswerRepository->canSelectBestAnswer($serializer->getActor(), $discussion);
+        resolve('log')->info($this->bestAnswerRepository->canSelectPostAsBestAnswer($serializer->getActor(), $post));
+
+        $attributes['canSelectAsBestAnswer'] = $this->bestAnswerRepository->canSelectPostAsBestAnswer($serializer->getActor(), $post);
 
         return $attributes;
     }

--- a/src/Console/NotifyCommand.php
+++ b/src/Console/NotifyCommand.php
@@ -88,7 +88,7 @@ class NotifyCommand extends Command
 
         $errors = [];
 
-        $query->chunkById(20, function ($discussions) use ( &$errors) {
+        $query->chunkById(20, function ($discussions) use (&$errors) {
             // Filter out discussions where the user can't select a post as best answer.
             // - The user must have permission to select a best answer on their own discussion
             // - The user must be able to select a post, whether they can select any post (including their own) or not.

--- a/src/Console/NotifyCommand.php
+++ b/src/Console/NotifyCommand.php
@@ -53,7 +53,6 @@ class NotifyCommand extends Command
     public function handle()
     {
         $days = (int) $this->settings->get('fof-best-answer.select_best_answer_reminder_days');
-        $canSelectOwn = (bool) (int) $this->settings->get('fof-best-answer.allow_select_own_post');
         $time = Carbon::now()->subDays($days);
 
         // set a max time period to go back, so we don't spam really old discussions too.
@@ -89,11 +88,12 @@ class NotifyCommand extends Command
 
         $errors = [];
 
-        $query->chunkById(20, function ($discussions) use ($canSelectOwn, &$errors) {
+        $query->chunkById(20, function ($discussions) use ( &$errors) {
             // Filter out discussions where the user can't select a post as best answer.
             // - The user must have permission to select a best answer on their own discussion
             // - The user must be able to select a post, whether they can select any post (including their own) or not.
-            $discussions = $discussions->filter(function ($d) use ($canSelectOwn) {
+            $discussions = $discussions->filter(function ($d) {
+                $canSelectOwn = $d->user->can('fof-best-answer.allow_select_own_post', $d);
                 $hasPermission = $d->user->can('selectBestAnswerOwnDiscussion', $d);
                 $canSelectPosts = $canSelectOwn || $d->posts()->where('user_id', '!=', $d->user_id)->count() != 0;
 

--- a/src/Repository/BestAnswerRepository.php
+++ b/src/Repository/BestAnswerRepository.php
@@ -71,7 +71,7 @@ class BestAnswerRepository
         }
 
         if ($user->id === $post->user_id) {
-            return (bool) $this->settings->get('fof-best-answer.allow_select_own_post');
+            return $user->can('fof-best-answer.allow_select_own_post', $post->discussion);
         }
 
         return true;

--- a/tests/integration/api/SetBestAnswerTest.php
+++ b/tests/integration/api/SetBestAnswerTest.php
@@ -195,7 +195,6 @@ class SetBestAnswerTest extends TestCase
      */
     public function user_can_set_own_post_as_best_answer_if_permitted(int $userId)
     {
-
         $response = $this->setBestAnswer($userId, 5, 2);
 
         $this->assertEquals(200, $response->getStatusCode());

--- a/tests/integration/api/SetBestAnswerTest.php
+++ b/tests/integration/api/SetBestAnswerTest.php
@@ -38,17 +38,22 @@ class SetBestAnswerTest extends TestCase
             ],
             'discussions' => [
                 ['id' => 1, 'title' => __CLASS__, 'user_id' => 2, 'created_at' => Carbon::now(), 'comment_count' => 2],
+                ['id' => 2, 'title' => 'Another discussion', 'user_id' => 3, 'created_at' => Carbon::now(), 'comment_count' => 1],
             ],
             'posts' => [
                 ['id' => 1, 'discussion_id' => 1, 'user_id' => 2, 'type' => 'comment', 'content' => 'post 1 - question', 'created_at' => Carbon::now()],
                 ['id' => 2, 'discussion_id' => 1, 'user_id' => 1, 'type' => 'comment', 'content' => 'post 2 - answer1', 'created_at' => Carbon::now()],
                 ['id' => 3, 'discussion_id' => 1, 'user_id' => 3, 'type' => 'comment', 'content' => 'post 2 - answer2', 'created_at' => Carbon::now()],
+                ['id' => 4, 'discussion_id' => 2, 'user_id' => 3, 'type' => 'comment', 'content' => 'question', 'created_at' => Carbon::now()],
+                ['id' => 5, 'discussion_id' => 2, 'user_id' => 3, 'type' => 'comment', 'content' => 'answer', 'created_at' => Carbon::now()],
             ],
             'discussion_tag' => [
                 ['discussion_id' => 1, 'tag_id' => 2],
+                ['discussion_id' => 2, 'tag_id' => 2],
             ],
             'group_permission' => [
                 ['group_id' => 4, 'permission' => 'discussion.selectBestAnswerNotOwnDiscussion', 'created_at' => Carbon::now()],
+                ['group_id' => 4, 'permission' => 'discussion.fof-best-answer.allow_select_own_post', 'created_at' => Carbon::now()],
             ],
             'group_user' => [
                 ['user_id' => 4, 'group_id' => 4],
@@ -72,6 +77,22 @@ class SetBestAnswerTest extends TestCase
         ];
     }
 
+    public static function unauthorizedUsersOwnPostProvider(): array
+    {
+        return [
+            [2],
+            [3],
+        ];
+    }
+
+    public static function permittedUsersOwnPostProvider(): array
+    {
+        return [
+            [1],
+            [4],
+        ];
+    }
+
     public function getDiscussion(int $userId): ResponseInterface
     {
         return $this->send(
@@ -85,12 +106,12 @@ class SetBestAnswerTest extends TestCase
         );
     }
 
-    public function setBestAnswer(int $userId, int $postId): ResponseInterface
+    public function setBestAnswer(int $userId, int $postId, int $discussionId = 1): ResponseInterface
     {
         return $this->send(
             $this->request(
                 'PATCH',
-                '/api/discussions/1',
+                '/api/discussions/'.$discussionId,
                 [
                     'json' => [
                         'data' => [
@@ -121,7 +142,6 @@ class SetBestAnswerTest extends TestCase
         $attributes = $data['data']['attributes'];
 
         $this->assertFalse($attributes['hasBestAnswer'], 'Expected no best answer post ID');
-        $this->assertTrue($attributes['canSelectBestAnswer'], 'Expected user to be able to set best answer');
 
         $response = $this->setBestAnswer($userId, 3);
 
@@ -150,10 +170,40 @@ class SetBestAnswerTest extends TestCase
         $attributes = $data['data']['attributes'];
 
         $this->assertFalse($attributes['hasBestAnswer'], 'Expected no best answer post ID');
-        $this->assertFalse($attributes['canSelectBestAnswer'], 'Expected user to not be able to set best answer');
 
         $response = $this->setBestAnswer($userId, 3);
 
         $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider unauthorizedUsersOwnPostProvider
+     */
+    public function user_cannot_set_own_post_as_best_answer_if_not_permitted(int $userId)
+    {
+        $response = $this->setBestAnswer($userId, 5, 2);
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider permittedUsersOwnPostProvider
+     */
+    public function user_can_set_own_post_as_best_answer_if_permitted(int $userId)
+    {
+
+        $response = $this->setBestAnswer($userId, 5, 2);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        $attributes = $data['data']['attributes'];
+
+        $this->assertEquals(5, $attributes['hasBestAnswer'], 'Expected best answer post ID to be 5');
     }
 }

--- a/tests/integration/api/UnsetBestAnswerTest.php
+++ b/tests/integration/api/UnsetBestAnswerTest.php
@@ -120,7 +120,6 @@ class UnsetBestAnswerTest extends TestCase
 
         $attributes = $data['data']['attributes'];
         $this->assertFalse($attributes['hasBestAnswer']);
-        $this->assertTrue($attributes['canSelectBestAnswer'], 'Expected user to be able to set a best answer');
 
         // Set a different post as best answer
         $response = $this->send(


### PR DESCRIPTION
1.x equivalent to #122 

**Fixes #0000**

**Changes proposed in this pull request:**
* Implement own post permission for selecting best answer

**Reviewers should focus on:**
> [!IMPORTANT]  
> This PR technically contains a breaking change in API. `discussion.canSelectBestAnswer()` is no longer available!

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
