### PR TITLE
[1.x] fix: change syntax of conditional extender

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -135,7 +135,7 @@ return [
         ->attributes(Api\AddTagAttributes::class),
 
     (new Extend\Conditional())
-        ->whenExtensionEnabled('flarum-audit', fn() => [
+        ->whenExtensionEnabled('flarum-audit', fn () => [
             (new Audit())
                 ->listen(BestAnswerSet::class, 'discussion.best_answer_set', function (BestAnswerSet $event) {
                     return [

--- a/extend.php
+++ b/extend.php
@@ -150,6 +150,6 @@ return [
                             'post_id'       => $event->post->id,
                         ];
                     }),
-        ];
-    }),
+            ];
+        }),
 ];

--- a/extend.php
+++ b/extend.php
@@ -135,7 +135,7 @@ return [
         ->attributes(Api\AddTagAttributes::class),
 
     (new Extend\Conditional())
-        ->whenExtensionEnabled('flarum-audit', [
+        ->whenExtensionEnabled('flarum-audit', fn() => [
             (new Audit())
                 ->listen(BestAnswerSet::class, 'discussion.best_answer_set', function (BestAnswerSet $event) {
                     return [

--- a/extend.php
+++ b/extend.php
@@ -135,19 +135,21 @@ return [
         ->attributes(Api\AddTagAttributes::class),
 
     (new Extend\Conditional())
-        ->whenExtensionEnabled('flarum-audit', fn () => [
-            (new Audit())
-                ->listen(BestAnswerSet::class, 'discussion.best_answer_set', function (BestAnswerSet $event) {
-                    return [
-                        'discussion_id' => $event->discussion->id,
-                        'post_id'       => $event->post->id,
-                    ];
-                })
-                ->listen(BestAnswerUnset::class, 'discussion.best_answer_unset', function (BestAnswerUnset $event) {
-                    return [
-                        'discussion_id' => $event->discussion->id,
-                        'post_id'       => $event->post->id,
-                    ];
-                }),
-        ]),
+        ->whenExtensionEnabled('flarum-audit', function () {
+            return [
+                (new Audit())
+                    ->listen(BestAnswerSet::class, 'discussion.best_answer_set', function (BestAnswerSet $event) {
+                        return [
+                            'discussion_id' => $event->discussion->id,
+                            'post_id'       => $event->post->id,
+                        ];
+                    })
+                    ->listen(BestAnswerUnset::class, 'discussion.best_answer_unset', function (BestAnswerUnset $event) {
+                        return [
+                            'discussion_id' => $event->discussion->id,
+                            'post_id'       => $event->post->id,
+                        ];
+                    }),
+        ];
+    }),
 ];


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #131**
The conditional extender appears to be always executed when the function call in the signature is missing

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
