### PR TITLE
[2.x] fix: only widen post footer when rendering the best-answer preview

### DIFF
--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -24,8 +24,17 @@
   }
 }
 
-.Post-footer {
+// Only widen the footer to full width when it actually renders the best-answer
+// preview block. Core lays .Post-footer out as an inline-block (height: 0) so
+// the likes/replies footer sits on the same line as the floated post actions;
+// forcing width: 100% on every .Post-footer breaks that for all posts, dropping
+// the likes/replies line below the actions with a large gap.
+// See flarum/framework#4765.
+.Post-footer:has(.item-bestAnswerPost) {
   width: 100%;
+}
+
+.Post-footer {
   .item-bestAnswerPost {
     padding: 10px 10px 0 10px;
     background-color: @best-answer-post-background;


### PR DESCRIPTION
### Problem

The extension applied `width: 100%` to **every** `.Post-footer`:

```less
.Post-footer {
  width: 100%;
  .item-bestAnswerPost { ... }
}
```

Flarum core lays the post footer out as a `height: 0` inline-block so the likes/replies line sits on the **same row** as the floated post actions (Reply/Like). Forcing `width: 100%` on all footers turns that into a full-width block, so on **every** post the likes/replies line drops below the actions with a large vertical gap — not just posts that show a best-answer preview.

Reported upstream at flarum/framework#4765 (visible on discuss.flarum.org and reproducible locally with only best-answer enabled; not reproducible on vanilla Flarum).

### Fix

Scope the full-width rule to footers that actually contain the preview block, so normal posts keep core's compact inline layout and only preview-bearing posts expand:

```less
.Post-footer:has(.item-bestAnswerPost) {
  width: 100%;
}
```

### Notes

- Uses the CSS `:has()` selector (baseline across all current browsers since late 2023), consistent with Flarum 2.x's browser targets.
- CSS-only change; no compiled assets committed.

### Testing

Locally with best-answer enabled: normal posts now show the tight inline footer (likes text and Reply/Like on one line); posts embedding a best-answer preview still expand to full width for the preview box.