### PR TITLE
[2.x] fix: extend the user directory sort map by import path

### DIFF
--- a/js/src/common/addBestAnswerCountSort.ts
+++ b/js/src/common/addBestAnswerCountSort.ts
@@ -1,12 +1,12 @@
 import { extend } from 'flarum/common/extend';
-import SortMap from 'ext:fof/user-directory/common/utils/SortMap';
 
 export default function addBestAnswerCountSort() {
-  if (!SortMap) {
-    return;
-  }
-
-  extend(SortMap.prototype, 'sortMap', function (map) {
+  // Extended by import path rather than by prototype: the user directory lazy
+  // loads its page and everything it pulls in, SortMap included, so the module
+  // does not exist yet when this runs. Passing the path defers the extension
+  // until the chunk is loaded — and does nothing at all if the extension is
+  // not installed, which is why no guard is needed here.
+  extend('ext:fof/user-directory/common/utils/SortMap', 'sortMap', function (map: Record<string, string>) {
     map.most_best_answers = '-bestAnswerCount';
     map.least_best_answers = 'bestAnswerCount';
   });


### PR DESCRIPTION
Prerequisite for FriendsOfFlarum/user-directory#130, which code splits the directory page. Safe to merge and release independently.

## The problem

`addBestAnswerCountSort.ts` statically imports `SortMap` from fof/user-directory and extends its prototype at boot:

```ts
import SortMap from 'ext:fof/user-directory/common/utils/SortMap';

if (!SortMap) return;

extend(SortMap.prototype, 'sortMap', function (map) { ... });
```

That works today because `SortMap` is in user-directory's main bundle. Once the directory page is lazy loaded, `SortMap` goes into the chunk with it, so at boot the module is not in the registry.

The existing guard means this fails *quietly* rather than throwing — the early return fires and the "Most best answers" / "Least best answers" options simply never get added to the directory's sort dropdown. Confirmed on a dev forum: with the extension enabled and the page split, both options were missing from the sort select with no error anywhere.

## The fix

Pass the import path to `extend` rather than the prototype, so the callback is deferred via `flarum.reg.onLoad` until the module registers:

```ts
extend('ext:fof/user-directory/common/utils/SortMap', 'sortMap', function (map) { ... });
```

This is the documented approach for [extending split modules](https://docs.flarum.org/2.x/extend/code-splitting).

The `if (!SortMap)` guard is removed along with the static import. It is no longer needed, and could not be kept in any case now that there is no module reference to test — a deferred handler for a module that never registers simply never runs, so the optional-dependency behaviour is preserved.

It is also correct with `SortMap` unsplit: `onLoad` fires immediately for an already-registered module. So this can merge and release before the user-directory change.

## Verification

Built and loaded against a dev forum running the code split branch of user-directory.

Before:

```
Default | Username (a-z) | Username (z-a) | Newest | Oldest |
Most discussions | Least discussions | Recently online | Longest away
```

After:

```
... | Most discussions | Least discussions | Most best answers |
Least best answers | Recently online | Longest away
```

No console errors. `grep 'reg.get("fof-user-directory"' dist/forum.js` → 0 matches. `yarn check-typings` clean.